### PR TITLE
Bump go version to current, install staticcheck

### DIFF
--- a/all-tools/Dockerfile
+++ b/all-tools/Dockerfile
@@ -34,7 +34,7 @@ RUN gem install --no-document --quiet \
         sqlint
 
 # Install GO and GO tools
-ENV GOLANG_VERSION 1.10.2
+ENV GOLANG_VERSION 1.11.4
 ENV GOPATH /go
 ENV PATH   $GOPATH/bin:/usr/local/go/bin:$PATH
 RUN curl -sSLo go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" \
@@ -44,6 +44,7 @@ RUN curl -sSLo go.tgz "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar
           github.com/golang/lint/golint \
           github.com/kisielk/errcheck \
           github.com/mdempsky/unconvert \
+          honnef.co/go/tools/cmd/staticcheck \
           honnef.co/go/tools/cmd/megacheck \
           >/dev/null
 

--- a/all-tools/check-tools
+++ b/all-tools/check-tools
@@ -27,6 +27,7 @@ echo "--- Installed tools ---" \
     && echo "go-gofmt: $(go version)" \
     && echo "go-golint: ??" \
     && echo "go-megacheck: ??" \
+    && echo "go-staticcheck: ??" \
     && echo "go-test: $(go version)" \
     && echo "go-unconvert: ??" \
     && echo "go-vet: $(go version)" \


### PR DESCRIPTION
This commit adds the `staticcheck` tool to this Docker image, for testing the
new [`go-staticcheck`](https://github.com/flycheck/flycheck/pull/1541) linter.