### PR TITLE
Add Emacs 24.3, so flycheck can be tested against its lowest-supported version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
   - IMAGE="emacs-cask" VERSION="26.3"
   - IMAGE="emacs-cask" VERSION="25.3"
   - IMAGE="emacs-cask" VERSION="24.5"
+  - IMAGE="emacs-cask" VERSION="24.3"
   - IMAGE="all-tools"  VERSION="latest"
 
 script:


### PR DESCRIPTION
Just noticed that `flycheck.el` claims to to work with Emacs 24.3 and up, but isn't tested against that version, which seems risky because a lot changed between Emacs 24.3 and 24.5. I thought I'd see what happened if I pushed a branch with a naïve change for this, but the build failed: so here I am opening a pull request from that branch for discussion. :-)